### PR TITLE
---

### DIFF
--- a/dl-tar/index.js
+++ b/dl-tar/index.js
@@ -219,7 +219,7 @@ module.exports = function dlTar(...args) {
 						return;
 					}
 
-					observer.complete();
+					setTimeout(() => observer.complete(), 1000);
 				});
 			} catch (err) {
 				ended = true;


### PR DESCRIPTION
In previous PR #33, the outdated dependency **pump** [^1] has been replace by native streams **pipeline** [^2], which intended to be drop-in replacement given ported by its original author (https://github.com/nodejs/node/pull/19828).

It seems to flaky for some Docker related setups (i.e. computing resources intensive), since it has a lot of moving parts (node & npm versions) involved, I'd like to patch with this minimal changes by having 1 second delay before the untar pipe proceed to its next tasks.

To preview & verify, for Node.js version >= **v16** (shipped with npm **v8**) could use the `overrides` syntax to select this patch by modify the `package.json`:
```diff
  },
+ "overrides": {
+   "purescript-installer": "github:imcotton/npm-installer#untar-pipe-racing-delay"
+ },
  "devDependencies": {
    "purescript": "~0.15.7"
  },
```

For Node.js **v14** consider adding an extra step in `Dockerfile` to upgrade builtin npm to **v8** first

```docker
FROM node:14
RUN npm install -g npm@8
```

----
resolves #37

/cc @mrskug @sjpeterson @rhendric

[^1]: https://github.com/mafintosh/pump
[^2]: https://nodejs.org/docs/latest-v14.x/api/stream.html#stream_stream_pipeline_streams_callback